### PR TITLE
More flexible rain file naming requirements + documentation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Changelog of threedi-urban-eia-nl
 - Set aggregation settings instead of validating schematisation
 - Improve method for parsing datetime from filename
 - Add option to use existing saved states simulation and skip creating a new one
+- More flexible rain file naming requirements + documentation
+
 
 0.0.5 (2025-12-19)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ Let op de volgende zaken:
   
 De berekening van de herhalingstijden wordt hier verder toegelicht: https://www.riool.net/presenteren-van-milieutechnisch-functioneren
 
-Om de statistieken over de simulaties te berekenen moeten de onderstaande aggregation settings zijn gedefinieerd. 
+De benodigde aggregation settings worden door de tool zelf ingesteld in de simulatie. Hier hoef je als gebruiker niets voor te doen (dit was in eerdere versies van deze tool wel het geval). De onderstaande aggregation settings worden toegepast.
 
 +---------------+--------------------+-----------+
 | Flow variable | Aggregation method | Time step |
@@ -43,16 +43,7 @@ Om de statistieken over de simulaties te berekenen moeten de onderstaande aggreg
 
 Dit betreft het cumulatieve volume dat over de overstort gaat, het cumulatieve volume in positieve richting en het cumulatieve volume in negatieve richting.
 
-Hiervoor kan je de volgende SQL gebruiken::
-
-    INSERT INTO aggregation_settings (flow_variable, aggregation_method, time_step)
-    VALUES
-        ('discharge', 'cum', '3600'),
-        ('discharge', 'cum_positive', '3600'),
-        ('discharge', 'cum_negative', '3600')
-    ;
-
-Zet de output time step ook hoog (bv 3600) omdat je anders erg grote results_3di.nc NetCDFs krijgt.
+Zet de output time step ook hoog (bv 3600) omdat je anders erg grote results_3di.nc NetCDFs krijgt bij het gebruik van DEBUG mode.
 
 Installatie
 -----------
@@ -67,11 +58,13 @@ Gebruikershandleiding
 Doorloop de volgende stappen om ervoor te zorgen dat deze tool correct werkt:
 
 #. Controleer de schematisatie en simulatie-instellingen (zie "Aandachtspunten 3Di model")
-#. Maak een map met alle neerslagbestanden die je in je simulaties wilt gebruiken. Deze regenbestanden moeten het 'min,mm'-formaat hebben, waarbij min de tijdstap in minuten is en mm de hoeveelheid regen die tijdens de tijdstap valt, in millimeters. Elke tijdstap wordt gescheiden door een nieuwe regel, zoals in het onderstaande voorbeeld::
+#. Maak een map met alle neerslagbestanden die je in je simulaties wilt gebruiken.
+#. De naam van het bestand moet het volgende format hebben: "{naam bui} {YYYYmmddHHMMSS}.csv", waarbij Y = jaar, m = maand, d = dag, H = uur, M = minuut, S = seconde. Bijvoorbeeld: "isahw122 19600822200000.csv". De bestandsextensie maakt niet uit.
+#. De inhoud van het bestand moet een CSV-indeling hebben, zonder kolomnamen/headers, met twee kolommen: tijdstap [minuten] en neerslag [mm/tijdstap]),mm'. Elke tijdstap wordt gescheiden door een nieuwe regel, zoals in het onderstaande voorbeeld::
 
-    0,5,0
-    30,1,5
-    60,0,0
+    0,5.0
+    30,1.5
+    60,0.0
 #. Maak een uitvoermap waarin de resultaatbestanden worden opgeslagen.
 #. Zoek de ID van uw 3Di-model op 3Di Management
 #. Voer op de opdrachtregel ``run-rain-series-simulations --help`` uit om te zien welke argumenten u moet opgeven.

--- a/threedi_urban_eia_nl/process_results.py
+++ b/threedi_urban_eia_nl/process_results.py
@@ -173,7 +173,7 @@ def download_results(
     while len(remaining) > 0:
         for simulation in remaining:
             simulation_id: int = simulation[0]
-            isahw: str = simulation[1].split("isahw")[1]
+            simulation_name: str = simulation[1]
             printProgressBar(total - len(remaining), total, "Downloading result files")
             status: SimulationStatus = api_call(
                 api.simulations_status_list, simulation_id
@@ -213,7 +213,7 @@ def download_results(
 
                     if debug and result.filename.startswith("log"):
                         "Download log files and unzip"
-                        sim_dir = simulations_dir / f"{simulation_id}-isahw{isahw}"
+                        sim_dir = simulations_dir / f"{simulation_id}-{simulation_name}"
                         sim_dir.mkdir(parents=True)
                         download = api_call(
                             api.simulations_results_files_download,

--- a/threedi_urban_eia_nl/rain_series_simulations.py
+++ b/threedi_urban_eia_nl/rain_series_simulations.py
@@ -388,7 +388,7 @@ def create_simulations_from_rain_events(
     files = [f for f in rain_files_dir.iterdir() if f.is_file()]
     for i, file in enumerate(files):
         printProgressBar(i + 1, len(files), "Creating rain event simulations")
-        # retrievie rain timeseries data
+        # retrieve rain timeseries data
         with open(file, "r") as f:
             timeseries = np.array(
                 [
@@ -404,7 +404,7 @@ def create_simulations_from_rain_events(
             warnings.append(f"Warning: {file.name} last rain intensity value is not 0")
 
         # parse datetime from filename (NL datetime to UTC to timezone unaware)
-        filename_datetime = datetime.strptime(file.name.split()[-1], "%Y%m%d%H%M%S")
+        filename_datetime = datetime.strptime(file.stem.split()[-1], "%Y%m%d%H%M%S")
         tz = pytz.timezone("Europe/Amsterdam")
         localized = tz.localize(filename_datetime)
         with_utc_time_zone = localized.astimezone(tz=pytz.UTC)


### PR DESCRIPTION
- Ignore file extension when parsing datetime from file
- Use simulation name directly instead of requiring that it contains the string "isahw"
- Update the documentation according to the changes that were made in all PRs